### PR TITLE
Add method to calculate the cache key for decorated function arguments

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -360,7 +360,7 @@ def test_cache_memoize_typed(cache: Cache):
 
 
 def test_cache_memoize_arg_normalization(cache: Cache):
-    """Test taht cache.memoize() normalizes argument ordering for positional and keyword
+    """Test that cache.memoize() normalizes argument ordering for positional and keyword
     arguments."""
 
     @cache.memoize(typed=True)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -375,7 +375,8 @@ def test_cache_memoize_arg_normalization(cache: Cache):
         ((), {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}),
         ((), {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5}),
     ):
-        func(*args, **kwargs)
+        cached = func(*args, **kwargs)
+        assert cache.get(func.cache_key(*args, **kwargs)) is cached
         assert len(cache) == 1
 
 
@@ -422,6 +423,7 @@ def test_cache_memoize_func_attrs(cache: Cache):
 
     assert memoized.cache is cache
     assert memoized.uncached is original
+    assert hasattr(memoized, "cache_key") and callable(memoized.cache_key)
 
     _, mark_x = memoized(value)
     assert mark_x == marker


### PR DESCRIPTION
When using the memoize decorator there is currently no way to modify cached items further (e.g. delete/update a single item) or check if an item exists.

This pull requests add an attribute to the decorated function to generate the same cache key for the provided arguments as when the function is called, to allow using all other operations of the underlying cache object.