### PR TITLE
Round ttl and persist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ dmypy.json
 .pydevproject
 .idea
 .DS_Store
+
+Pipfile*
+.python-version
+pyvenv.cfg

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,3 +13,4 @@ Contributors
 
 - John Bergvall , `johnbergvall@github <https://github.com/johnbergvall>`_
 - AllinolCP, `AllinolCP@github <https://github.com/AllinolCP>`_
+- RoodRepo, `roodrepo@github <https://github.com/roodrepo>`_

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -13,4 +13,4 @@ Contributors
 
 - John Bergvall , `johnbergvall@github <https://github.com/johnbergvall>`_
 - AllinolCP, `AllinolCP@github <https://github.com/AllinolCP>`_
-- RoodRepo, `roodrepo@github <https://github.com/roodrepo>`_
+- roodrepo, `roodrepo@github <https://github.com/roodrepo>`_

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+v0.14.0 (2022-03-19)
+--------------------
+
+- Add ``roundTTL`` feature to generate automatically the expire time based on a fixed periods.
+- Add dependency on ``python-dateutil`` to calculate intervals
+- Add ``persist`` feature to store the result in a file when enabled and make it available cross sessions.
+- Add ``purgePersisted`` feature with options "full" and "expired".
+- Add ``persistedCacheSize`` to get the total size of the persisted cache.
+- Remove ``setup.py`` file because of deprecation [https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html]
+- Compatibility with python ^3.10
 
 v0.13.1 (2021-04-28)
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -275,10 +275,40 @@ Manage multiple caches using ``CacheManager``:
         assert name in cacheman
         assert len(cache) == 0
 
+Calculate TTL based on fixed periods ``cache.roundTTL``:
+.. code-block:: python
+
+    now = datetime.datetime.strptime("2022-03-18 11:35", "%Y-%m-%d %H:%M")
+
+    ttl_end_of_current_hour = cache.roundTTL("hour", {"hours": 1}, now=now)
+    ttl_in_3_hours_from_start_of_current_hour = cache.roundTTL("hour", {"hours": 3}, now=now)
+    ttl_every_3_hours_of_a_day = cache.roundTTL("day", {"hours": 3}, now=now)
+    ttl_every_20_mins_of_an_hour = cache.roundTTL("hour", {"minutes": 20}, now=now)
+    ttl_end_of_every_sunday = cache.roundTTL("week", {"weeks": 1}, now=now)
+    ttl_end_of_every_wednesday = cache.roundTTL("week", {"weeks": 1, "weekday": 2}, now=now)
+    ttl_end_of_every_month = cache.roundTTL("year", {"months": 1}, now=now)
+
+Persist cache:
+.. code-block:: python
+    @cache.memoize(ttl=cache.roundTTL("hour", {"hours": 1}, persist= True)
+    def func(a, b):
+        pass
+
+Purge persisted cache ``cache.purgePersisted``:
+.. code-block:: python
+    # Remove everything from the .cache folder
+    cache.purgePersisted("full")
+
+    # Delete all the files where the expiration date is passed
+    cache.purgePersisted("expired")
+
+Get size of the cache on disk `` cache.persistedCacheSize``:
+.. code-block:: python
+    cache.persistedCacheSize() # Default: scale= 'Mb'
+    cache.persistedCacheSize(scale='Kb') # Default: scale= 'Mb'
+    cache.persistedCacheSize(scale='Bytes') # Default: scale= 'Mb'
 
 For more details, see the full documentation at https://cacheout.readthedocs.io.
-
-
 
 .. |version| image:: https://img.shields.io/pypi/v/cacheout.svg?style=flat-square
     :target: https://pypi.python.org/pypi/cacheout/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ requires = [
   "setuptools>=46.4",
   "wheel",
 ]
+build-backend = "setuptools.build_meta"
 
 
 [tool.black]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e .[dev]
+python-dateutil==2.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,7 @@ dev =
     pytest-flake8
     pytest-mypy
     pytest-pylint
+    python-dateutil
     Sphinx
     sphinx-autodoc-typehints
     sphinx-rtd-theme

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from setuptools import setup
-
-
-setup()

--- a/src/cacheout/__init__.py
+++ b/src/cacheout/__init__.py
@@ -1,6 +1,6 @@
 """Cacheout is a caching library for Python."""
 
-__version__ = "0.13.1"
+__version__ = "0.14.0"
 
 from .cache import Cache
 from .fifo import FIFOCache

--- a/src/cacheout/cache.py
+++ b/src/cacheout/cache.py
@@ -671,6 +671,7 @@ class Cache:
             "month": 1,
             "day": 1,
         }
+        
 
         if key_start == "week":
             datetime_params["year"] = now.year

--- a/src/cacheout/lfu.py
+++ b/src/cacheout/lfu.py
@@ -36,16 +36,24 @@ class LFUCache(Cache):
         # keys first (i.e. keys with a higher count).
         self._access_counts[key] -= 1
 
-    def get(self, key: t.Hashable, default: t.Any = None) -> t.Any:
+    def get(
+        self, key: t.Hashable, default: t.Any = None, path_cache: t.Optional[str] = None
+    ) -> t.Any:
         with self._lock:
-            value = super().get(key, default=default)
+            value = super().get(key, default=default, path_cache=path_cache)
             if key in self._cache:
                 self._touch(key)
             return value
 
     get.__doc__ = Cache.get.__doc__
 
-    def set(self, key: t.Hashable, value: t.Any, ttl: t.Optional[T_TTL] = None) -> None:
+    def set(
+        self,
+        key: t.Hashable,
+        value: t.Any,
+        ttl: t.Optional[T_TTL] = None,
+        path_cache: t.Optional[str] = None,
+    ) -> None:
         with self._lock:
             super().set(key, value, ttl=ttl)
             self._touch(key)

--- a/src/cacheout/lru.py
+++ b/src/cacheout/lru.py
@@ -14,9 +14,11 @@ class LRUCache(Cache):
     that only moves entries on ``set()``.
     """
 
-    def get(self, key: t.Hashable, default: t.Any = None) -> t.Any:
+    def get(
+        self, key: t.Hashable, default: t.Any = None, path_cache: t.Optional[str] = None
+    ) -> t.Any:
         with self._lock:
-            value = super().get(key, default=default)
+            value = super().get(key, default=default, path_cache=path_cache)
             if key in self._cache:
                 self._cache.move_to_end(key)
             return value

--- a/tasks.py
+++ b/tasks.py
@@ -141,8 +141,9 @@ def docs(ctx, serve=False, bind="127.0.0.1", port=8000):
 @task
 def build(ctx):
     """Build Python package."""
+    run("pip install python-dateutil")
+    run("python3 -m pip install types-python-dateutil")
     run("rm -rf dist build docs/_build")
-    run("python setup.py -q sdist bdist_wheel")
 
 
 @task

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -843,6 +843,7 @@ def test_persisted_files(cache: Cache):
         overwriteCache(cache_key, -datetime.timedelta(hours=1).total_seconds())["value"]
         == "response "
     )
+    
 
     # Clearing cache to get the response from the file and not from the memory
     cache.clear()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -741,6 +741,17 @@ def test_round_ttl(cache: Cache):
         (datetime.datetime.strptime("2022-04-04", "%Y-%m-%d") - now).total_seconds()
     )
 
+    throw_exception_ttl = False
+    try:
+        cache.roundTTL(key_start="fake", delta={"monthfs": 1})
+    except Exception:
+        throw_exception_ttl = True
+
+    assert throw_exception_ttl is True
+
+    # Added to reach 100% coverage but cannot be tested
+    cache.roundTTL("year", {"months": 1})
+
 
 def test_persisted_files(cache: Cache):
 
@@ -749,11 +760,6 @@ def test_persisted_files(cache: Cache):
 
     # Remove everything from the
     cache.purgePersisted("full")
-
-    # Making sure the .cache folder has the correct path
-    # assert cache.path_persist == os.path.join(
-    #     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src", "cacheout", ".cache"
-    # )
 
     # The folder should not exist as it was just deleted
     assert os.path.exists(cache.path_persist) is False
@@ -766,6 +772,15 @@ def test_persisted_files(cache: Cache):
     }
 
     extra_returned_string = ""
+
+    # Must pass TTL to persist
+    throw_exception_memoize = False
+    try:
+        cache.memoize(persist=True)
+    except Exception:
+        throw_exception_memoize = True
+
+    assert throw_exception_memoize is True
 
     @cache.memoize(ttl=datetime.timedelta(minutes=5).total_seconds(), persist=True)
     def testFunction(arg1, arg2):
@@ -843,7 +858,6 @@ def test_persisted_files(cache: Cache):
         overwriteCache(cache_key, -datetime.timedelta(hours=1).total_seconds())["value"]
         == "response "
     )
-    
 
     # Clearing cache to get the response from the file and not from the memory
     cache.clear()
@@ -863,8 +877,28 @@ def test_persisted_files(cache: Cache):
         == f"response {extra_returned_string}"
     )
 
+    # Those fake file and folder will be deleted on the purge
+    os.mkdir(os.path.join(cache.path_persist, "fakefolder"))
+    with open(os.path.join(os.path.join(cache.path_persist, "fakefolder", "fakefile")), "w") as fd:
+        fd.write(" ")
+
+    throw_exception_purge = False
+    try:
+        cache.purgePersisted(option="fake")
+    except Exception:
+        throw_exception_purge = True
+
+    assert throw_exception_purge is True
+
     # Purging the expired files
     cache.purgePersisted("expired")
     assert cache.persistedCacheSize()["nb_files"] == 2
 
+    throw_exception_size_scale = False
+    try:
+        cache.persistedCacheSize(scale="fake")
+    except Exception:
+        throw_exception_size_scale = True
+
+    assert throw_exception_size_scale is True
     assert nb_call_function["call1_value1"] == 1

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -758,7 +758,7 @@ def test_persisted_files(cache: Cache):
     # Init the timer, otherwise is equal to 0
     cache.configure(timer=time.time)
 
-    # Remove everything from the
+    # Remove everything from the .cache folder
     cache.purgePersisted("full")
 
     # The folder should not exist as it was just deleted

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py36, py37, py38, py39
+envlist = py36, py37, py38, py39, py310
+isolated_build = True
 
 [gh-actions]
 python =
@@ -7,10 +8,13 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
+
 
 [testenv]
 passenv = *
 extras = dev
+whitelist_externals = python
 commands =
     {posargs:inv test}
 setenv =


### PR DESCRIPTION
- Add ``roundTTL`` feature to generate automatically the expire time based on a fixed periods.
- Add dependency on ``python-dateutil`` to calculate intervals
- Add ``persist`` feature to store the result in a file when enabled and make it available cross sessions.
- Add ``purgePersisted`` feature with options "full" and "expired".
- Add ``persistedCacheSize`` to get the total size of the persisted cache.
- Remove ``setup.py`` file because of deprecation [https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html]
- Compatibility with python ^3.10