### PR TITLE
Update README.rst adding clarification for TTL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -125,7 +125,7 @@ Provide a global default:
     assert 'missing' in cache3
 
 
-Set the TTL (time-to-live) expiration per entry:
+Set the TTL (time-to-live) expiration (by default, in milliseconds if timer=time.time) per entry:
 
 .. code-block:: python
 


### PR DESCRIPTION
Nothing in the documentation clarifying the default unit for TTL that it would be in milliseconds if `timer=time.time`