### PR TITLE
cache.py: item_ttl

### DIFF
--- a/src/cacheout/cache.py
+++ b/src/cacheout/cache.py
@@ -461,7 +461,10 @@ class Cache:
                     return -2
                 return -1
             ttl = expire_time - self.timer()
-            return ttl if ttl > 0 else -2
+            if ttl > 0:
+                return ttl
+            self._delete(key)
+            return -2
 
     def evict(self) -> int:
         """

--- a/src/cacheout/cache.py
+++ b/src/cacheout/cache.py
@@ -442,6 +442,26 @@ class Cache:
         """
         with self._lock:
             return self._expire_times.copy()
+        
+    def item_ttl(self, key: t.Hashable) -> T_TTL:
+        """
+        Returns the remaining time to live of a key that has a TTL.
+
+        Args:
+            key: Cache key to review.
+
+        Returns:
+            float: the remaining time to live of item
+            int: ``-1`` if the key exists but has no associated expire, ``-2`` if key didn't exist.
+        """
+        with self._lock:
+            expire_time = self._expire_times.copy().get(key)
+            if not expire_time:
+                if not self._get(key):
+                    return -2
+                return -1
+            ttl = expire_time - self.timer()
+            return ttl if ttl > 0 else -2
 
     def evict(self) -> int:
         """

--- a/src/cacheout/cache.py
+++ b/src/cacheout/cache.py
@@ -442,7 +442,7 @@ class Cache:
         """
         with self._lock:
             return self._expire_times.copy()
-        
+
     def get_ttl(self, key: t.Hashable) -> t.Optional[T_TTL]:
         """
         Return the remaining time to live of a key that has a TTL.
@@ -462,10 +462,6 @@ class Cache:
                 return None
 
             ttl = expire_time - self.timer()
-            if ttl <= 0:
-                self._delete(key)
-                return None
-
             return ttl
 
     def evict(self) -> int:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -326,21 +326,20 @@ def test_cache_delete_expired(cache: Cache, timer: Timer):
     for key in non_ttl_keys:
         assert cache.has(key)
 
- 
+
 def test_cache_get_ttl(cache: Cache, timer: Timer):
     """Test that cache.get_ttl() will return the remaining time to live of a key that has a TTL."""
     cache.set('a', 1, ttl=1)
     cache.set('b', 2, ttl=2)
+    cache.set('c', 3)
 
     assert cache.get_ttl('a') == 1
 
     timer.time = 1
-    
-    assert cache.get_ttl('a') is None
 
-    assert cache.has('a') is False
-    
+    assert cache.get_ttl('a') is None
     assert cache.get_ttl('b') == 1
+    assert cache.get_ttl('c') is None
 
 
 def test_cache_evict(cache: Cache):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -329,17 +329,17 @@ def test_cache_delete_expired(cache: Cache, timer: Timer):
 
 def test_cache_get_ttl(cache: Cache, timer: Timer):
     """Test that cache.get_ttl() will return the remaining time to live of a key that has a TTL."""
-    cache.set('a', 1, ttl=1)
-    cache.set('b', 2, ttl=2)
-    cache.set('c', 3)
+    cache.set("a", 1, ttl=1)
+    cache.set("b", 2, ttl=2)
+    cache.set("c", 3)
 
-    assert cache.get_ttl('a') == 1
+    assert cache.get_ttl("a") == 1
 
     timer.time = 1
 
-    assert cache.get_ttl('a') is None
-    assert cache.get_ttl('b') == 1
-    assert cache.get_ttl('c') is None
+    assert cache.get_ttl("a") is None
+    assert cache.get_ttl("b") == 1
+    assert cache.get_ttl("c") is None
 
 
 def test_cache_evict(cache: Cache):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -326,6 +326,22 @@ def test_cache_delete_expired(cache: Cache, timer: Timer):
     for key in non_ttl_keys:
         assert cache.has(key)
 
+ 
+def test_cache_get_ttl(cache: Cache, timer: Timer):
+    """Test that cache.get_ttl() will return the remaining time to live of a key that has a TTL."""
+    cache.set('a', 1, ttl=1)
+    cache.set('b', 2, ttl=2)
+
+    assert cache.get_ttl('a') == 1
+
+    timer.time = 1
+    
+    assert cache.get_ttl('a') is None
+
+    assert cache.has('a') is False
+    
+    assert cache.get_ttl('b') == 1
+
 
 def test_cache_evict(cache: Cache):
     """Test that cache.evict() will remove cache keys to make room."""


### PR DESCRIPTION
This function is the same as the [TTL ](https://redis.io/commands/ttl/) in redis.

If a key expires, it will be deleted and return -2.