### PR TITLE
rename EvictionCause to RemovalCause

### DIFF
--- a/src/cacheout/__init__.py
+++ b/src/cacheout/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "0.14.1"
 
-from .cache import Cache, EvictionCause
+from .cache import Cache, RemovalCause
 from .fifo import FIFOCache
 from .lfu import LFUCache
 from .lifo import LIFOCache

--- a/src/cacheout/cache.py
+++ b/src/cacheout/cache.py
@@ -26,7 +26,7 @@ UNSET = object()
 
 class RemovalCause(Enum):
     """
-    An enum to represent the cause for the eviction of a cache entry.
+    An enum to represent the cause for the removal of a cache entry.
 
     - DELETE: indicates that the cache entry was deleted by delete() or delete_many() explicitly.
     - SET: indicates that the cache entry was replaced with a new value by set() or set_many().

--- a/src/cacheout/cache.py
+++ b/src/cacheout/cache.py
@@ -24,7 +24,7 @@ T_FILTER = t.Union[str, t.List[t.Hashable], t.Pattern, t.Callable]
 UNSET = object()
 
 
-class EvictionCause(Enum):
+class RemovalCause(Enum):
     """
     An enum to represent the cause for the eviction of a cache entry.
 
@@ -84,7 +84,7 @@ class Cache:
         ttl: T_TTL = 0,
         timer: t.Callable[[], T_TTL] = time.time,
         default: t.Any = None,
-        on_delete: t.Optional[t.Callable[[t.Hashable, t.Any, EvictionCause], None]] = None,
+        on_delete: t.Optional[t.Callable[[t.Hashable, t.Any, RemovalCause], None]] = None,
     ):
         self.maxsize = maxsize
         self.ttl = ttl
@@ -239,7 +239,7 @@ class Cache:
             value = self._cache[key]
 
             if self.expired(key):
-                self._delete(key, EvictionCause.EXPIRED)
+                self._delete(key, RemovalCause.EXPIRED)
                 raise KeyError
         except KeyError:
             if default is None:
@@ -334,7 +334,7 @@ class Cache:
         if key not in self._cache:
             self.evict()
 
-        self._delete(key, EvictionCause.SET)
+        self._delete(key, RemovalCause.SET)
         self._cache[key] = value
 
         if ttl and ttl > 0:
@@ -367,9 +367,9 @@ class Cache:
             int: ``1`` if key was deleted, ``0`` if key didn't exist.
         """
         with self._lock:
-            return self._delete(key, EvictionCause.DELETE)
+            return self._delete(key, RemovalCause.DELETE)
 
-    def _delete(self, key: t.Hashable, cause: EvictionCause) -> int:
+    def _delete(self, key: t.Hashable, cause: RemovalCause) -> int:
         count = 0
 
         try:
@@ -414,7 +414,7 @@ class Cache:
         with self._lock:
             keys = self._filter_keys(iteratee)
             for key in keys:
-                count += self._delete(key, EvictionCause.DELETE)
+                count += self._delete(key, RemovalCause.DELETE)
         return count
 
     def delete_expired(self) -> int:
@@ -439,7 +439,7 @@ class Cache:
 
         for key, expiration in expire_times.items():
             if expiration <= expires_on:
-                count += self._delete(key, EvictionCause.EXPIRED)
+                count += self._delete(key, RemovalCause.EXPIRED)
         return count
 
     def expired(self, key: t.Hashable, expires_on: t.Optional[T_TTL] = None) -> bool:
@@ -512,7 +512,7 @@ class Cache:
         with self._lock:
             while self.full():
                 try:
-                    self._popitem(EvictionCause.FULL)
+                    self._popitem(RemovalCause.FULL)
                 except KeyError:  # pragma: no cover
                     break
                 count += 1
@@ -530,9 +530,9 @@ class Cache:
         """
         with self._lock:
             self._delete_expired()
-            return self._popitem(EvictionCause.POPITEM)
+            return self._popitem(RemovalCause.POPITEM)
 
-    def _popitem(self, cause: EvictionCause):
+    def _popitem(self, cause: RemovalCause):
         try:
             key = next(self)
         except StopIteration:

--- a/src/cacheout/lfu.py
+++ b/src/cacheout/lfu.py
@@ -3,7 +3,7 @@
 from collections import Counter
 import typing as t
 
-from .cache import T_TTL, Cache, EvictionCause
+from .cache import T_TTL, Cache, RemovalCause
 
 
 class LFUCache(Cache):
@@ -59,7 +59,7 @@ class LFUCache(Cache):
 
     add.__doc__ = Cache.add.__doc__
 
-    def _delete(self, key: t.Hashable, cause: EvictionCause) -> int:
+    def _delete(self, key: t.Hashable, cause: RemovalCause) -> int:
         count = super()._delete(key, cause)
 
         try:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,7 +5,7 @@ import typing as t
 
 import pytest
 
-from cacheout import Cache, EvictionCause
+from cacheout import Cache, RemovalCause
 
 
 parametrize = pytest.mark.parametrize
@@ -722,24 +722,24 @@ def test_cache_on_delete(cache: Cache, timer: Timer):
     cache.on_delete = on_delete
     cache.set("DELETE", 1)
     cache.delete("DELETE")
-    assert log == f"DELETE:1 {EvictionCause.DELETE.value}"
+    assert log == f"DELETE:1 {RemovalCause.DELETE.value}"
 
     cache.set("SET", 1)
     cache.set("SET", 2)
-    assert log == f"SET:1 {EvictionCause.SET.value}"
+    assert log == f"SET:1 {RemovalCause.SET.value}"
 
     cache.clear()
     cache.set("POPITEM", 1)
     cache.popitem()
-    assert log == f"POPITEM:1 {EvictionCause.POPITEM.value}"
+    assert log == f"POPITEM:1 {RemovalCause.POPITEM.value}"
 
     cache.set("EXPIRED", 1, ttl=1)
     timer.time = 1
     cache.delete_expired()
-    assert log == f"EXPIRED:1 {EvictionCause.EXPIRED.value}"
+    assert log == f"EXPIRED:1 {RemovalCause.EXPIRED.value}"
 
     cache.clear()
     cache.maxsize = 1
     cache.set("FULL", 1)
     cache.set("OVERFLOW", 2)
-    assert log == f"FULL:1 {EvictionCause.FULL.value}"
+    assert log == f"FULL:1 {RemovalCause.FULL.value}"


### PR DESCRIPTION
In most caches([redis](https://redis.io/docs/reference/eviction/)、[caffeine](https://github.com/ben-manes/caffeine/wiki/Eviction) and etc.), eviction means the entry is removed due to `maxsize` limit. But `on_delete` callback will be executed in all removal cases. `EvictionCause` can lead to a misunderstanding, `RemovalCause` should be a better name.