### PR TITLE
feat: on-set callback

### DIFF
--- a/src/cacheout/__init__.py
+++ b/src/cacheout/__init__.py
@@ -2,7 +2,7 @@
 
 __version__ = "0.15.0"
 
-from .cache import Cache, RemovalCause
+from .cache import UNSET, Cache, RemovalCause
 from .fifo import FIFOCache
 from .lfu import LFUCache
 from .lifo import LIFOCache

--- a/src/cacheout/lfu.py
+++ b/src/cacheout/lfu.py
@@ -59,7 +59,7 @@ class LFUCache(Cache):
 
     add.__doc__ = Cache.add.__doc__
 
-    def _delete(self, key: t.Hashable, cause: RemovalCause) -> int:
+    def _delete(self, key: t.Hashable, cause: t.Optional[RemovalCause] = None) -> int:
         count = super()._delete(key, cause)
 
         try:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -5,7 +5,7 @@ import typing as t
 
 import pytest
 
-from cacheout import Cache, RemovalCause
+from cacheout import UNSET, Cache, RemovalCause
 
 
 parametrize = pytest.mark.parametrize
@@ -763,19 +763,19 @@ def test_cache_on_get(cache: Cache):
 
 def test_cache_on_set(cache: Cache):
     """Test that on_set(cache) callback."""
-    log = ""
+    log = {}
 
     def on_set(key, new_value, old_value):
         nonlocal log
-        log = f"{key}={new_value}, old_value={old_value}"
+        log = {"key": key, "new_value": new_value, "old_value": old_value}
 
     cache.on_set = on_set
 
     cache.set("a", 1)
-    assert re.match(r"^a=1, old_value=<object object at 0x.*>$", log)
+    assert log == {"key": "a", "new_value": 1, "old_value": UNSET}
 
     cache.set("a", 2)
-    assert log == "a=2, old_value=1"
+    assert log == {"key": "a", "new_value": 2, "old_value": 1}
 
 
 def test_cache_stats__disabled_by_default(cache: Cache):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -726,10 +726,6 @@ def test_cache_on_delete(cache: Cache, timer: Timer):
     cache.delete("DELETE")
     assert log == f"DELETE=1, RemovalCause={RemovalCause.DELETE.value}"
 
-    cache.set("SET", 1)
-    cache.set("SET", 2)
-    assert log == f"SET=1, RemovalCause={RemovalCause.SET.value}"
-
     cache.clear()
     cache.set("POPITEM", 1)
     cache.popitem()
@@ -763,6 +759,23 @@ def test_cache_on_get(cache: Cache):
 
     cache.get("miss")
     assert log == "miss=None, existed=False"
+
+
+def test_cache_on_set(cache: Cache):
+    """Test that on_set(cache) callback."""
+    log = ""
+
+    def on_set(key, new_value, old_value):
+        nonlocal log
+        log = f"{key}={new_value}, old_value={old_value}"
+
+    cache.on_set = on_set
+
+    cache.set("a", 1)
+    assert re.match(r"^a=1, old_value=<object object at 0x.*>$", log)
+
+    cache.set("a", 2)
+    assert log == "a=2, old_value=1"
 
 
 def test_cache_stats__disabled_by_default(cache: Cache):


### PR DESCRIPTION
### Usage

set `on_set` callback.

```python
cache = Cache(on_set=on_set)
```


`on_set` is a callable object.

```python
Callable[[key: Hashable, new_value: Any, old_value: Any],  None]
```

`key` is the cache key.

`new_value` is the value is set.

`old_value` is the value is replaced(if the key didn't exist before, it's `UNSET`).